### PR TITLE
Fix bug trailing semicolon

### DIFF
--- a/GrafanaSnapshot/feature/snapshots.py
+++ b/GrafanaSnapshot/feature/snapshots.py
@@ -21,7 +21,7 @@ class Snapshots(Base):
         dashboards = {}
         for dashboard_info in dashboards_info:
             uid = dashboard_info["uid"]
-            dashboards[dashboard_info['uri']] = self.api.dashboard.get_dashboard(uid);
+            dashboards[dashboard_info['uri']] = self.api.dashboard.get_dashboard(uid)
 
         snapshot_list = []
         for uri, dashboard in dashboards.items():


### PR DESCRIPTION
As described in #15 , in the file GrafanaSnapshot/feature/snapshots.py Line 24 there seems to be a semicolon that was left over after this commit:

https://github.com/SN3-K/grafana-snapshot/blob/1ee72d3f86ec0cced8e5c169f4fce41832e301d9/GrafanaSnapshotLibrary/grafana.py#L19

Fix is obvious, I simply removed the semicolon

Closes #15 