### PR TITLE
Allow for non default port grafana instances for get_snapshot_by_key

### DIFF
--- a/GrafanaSnapshot/feature/base.py
+++ b/GrafanaSnapshot/feature/base.py
@@ -1,5 +1,6 @@
 class Base(object):
-    def __init__(self, api, host, protocol):
+    def __init__(self, api, host, protocol, port=3000):
         self.api = api
         self.host = host
         self.protocol = protocol
+        self.port = port

--- a/GrafanaSnapshot/feature/snapshots.py
+++ b/GrafanaSnapshot/feature/snapshots.py
@@ -51,7 +51,7 @@ class Snapshots(Base):
         snapshot_list = []
         for snapshot in snapshot:
             if key in snapshot["name"]:
-                url=snapshot["name"]+" : "+self.protocol+"://"+self.host+":3000/dashboard/snapshot/"+snapshot["key"]
+                url=snapshot["name"]+" : "+self.protocol+"://"+self.host+":"+str(self.port)+"/dashboard/snapshot/"+snapshot["key"]
                 snapshot_list.append(url)
 
         return snapshot_list

--- a/GrafanaSnapshot/snapshot_face.py
+++ b/GrafanaSnapshot/snapshot_face.py
@@ -32,4 +32,4 @@ class SnapshotFace:
             protocol=protocol,
             verify=verify,
         )
-        self.snapshots = Snapshots(self.api, host, protocol)
+        self.snapshots = Snapshots(self.api, host, protocol, port)


### PR DESCRIPTION
Changed the hard-coded port value in Snapshots.get_snapshot_by_key, this will allow for non default port deployment compatibility. 


Closes #13 